### PR TITLE
Add error handling for clipboard operation

### DIFF
--- a/source/Transmittal/ViewModels/TransmittalViewModel.cs
+++ b/source/Transmittal/ViewModels/TransmittalViewModel.cs
@@ -1206,7 +1206,15 @@ internal partial class TransmittalViewModel : BaseViewModel, IStatusRequester, I
             }
         }
 
-        System.Windows.Clipboard.SetText(emailAddresses.ToString());
+        try
+        {
+            System.Windows.Clipboard.SetText(emailAddresses.ToString());
+        }
+        catch(Exception ex)
+        {
+            _logger.LogError(ex, "Error copying email addresses to clipboard");
+            _logger.LogError("Email addresses : {emailAddresses}", emailAddresses.ToString());
+        }
     }
 
     private void OpenProgressWindow()


### PR DESCRIPTION
Introduced error handling around `System.Windows.Clipboard.SetText`
to catch and log exceptions. This enhances robustness by logging
errors that occur during the clipboard operation, aiding in
diagnosing issues related to copying email addresses.