### PR TITLE
Refine Revit package dependencies

### DIFF
--- a/source/Transmittal/Transmittal.csproj
+++ b/source/Transmittal/Transmittal.csproj
@@ -79,8 +79,10 @@
 		<PackageReference Include="Syncfusion.Tools.WPF" Version="24.2.7" />
 		<PackageReference Include="Nice3point.Revit.Api.RevitAPI" Version="$(RevitVersion).*" />
 		<PackageReference Include="Nice3point.Revit.Api.RevitAPIUI" Version="$(RevitVersion).*" />	
-		<PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*" />	
-		<PackageReference Include="Nice3point.Revit.Extensions" Version="$(RevitVersion).*" />	
+		<PackageReference Include="Nice3point.Revit.Extensions" Version="$(RevitVersion).*" />
+
+		<PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).0.0" Condition="$(RevitVersion) == '2025'"/>
+		<PackageReference Include="Nice3point.Revit.Toolkit" Version="$(RevitVersion).*" Condition="$(RevitVersion) &lt; '2025'"/>
 
 		<!--IOC-->
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="7.*" />


### PR DESCRIPTION
Adjusted the project's package references to better align with different versions of Revit software. Removed and then re-added `Nice3point.Revit.Extensions` to correct a possible mistake. Introduced conditional references for `Nice3point.Revit.Toolkit` based on the `RevitVersion` variable, specifying `2025.0.0` for Revit 2025 and allowing flexibility for other versions. This ensures compatibility across various Revit versions.