### PR TITLE
Downgrade Serilog packages and update document context

### DIFF
--- a/source/Transmittal.Desktop/Transmittal.Desktop.csproj
+++ b/source/Transmittal.Desktop/Transmittal.Desktop.csproj
@@ -78,8 +78,8 @@
 	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />
 
 	  <!--Logging-->
-	  <PackageReference Include="Serilog.Sinks.Debug" Version="3.*" />
-	  <PackageReference Include="Serilog.Sinks.File" Version="6.*" />
+	  <PackageReference Include="Serilog.Sinks.Debug" Version="2.*" />
+	  <PackageReference Include="Serilog.Sinks.File" Version="5.*" />
 	  <PackageReference Include="Serilog.Extensions.Hosting" Version="8.*" />
   </ItemGroup>
 

--- a/source/Transmittal/Commands/CommandImportSettings.cs
+++ b/source/Transmittal/Commands/CommandImportSettings.cs
@@ -19,7 +19,7 @@ internal class CommandImportSettings : ExternalCommand
     public override void Execute()
     {
         App.CachedUiApp = Context.UiApplication;
-        App.RevitDocument = Context.Document;
+        App.RevitDocument = Context.ActiveDocument;
 
         string jsonFilePath;
 

--- a/source/Transmittal/Transmittal.csproj
+++ b/source/Transmittal/Transmittal.csproj
@@ -88,8 +88,8 @@
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
 
 		<!--Logging-->
-		<PackageReference Include="Serilog.Sinks.Debug" Version="3.*" />
-		<PackageReference Include="Serilog.Sinks.File" Version="6.*" />
+		<PackageReference Include="Serilog.Sinks.Debug" Version="2.*" />
+		<PackageReference Include="Serilog.Sinks.File" Version="5.*" />
 		<!--<PackageReference Include="Serilog.Extensions.Hosting" Version="7.*" />-->
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="7.*" Condition="'$(TargetFramework)' == 'net48'" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />


### PR DESCRIPTION
Downgraded Serilog.Sinks.Debug to 2.* and Serilog.Sinks.File to 5.* in Transmittal.Desktop.csproj and Transmittal.csproj for compatibility. Updated CommandImportSettings.cs to use Context.ActiveDocument instead of Context.Document. Added conditional package references in Transmittal.csproj for different target frameworks.