### PR TITLE
Update Syncfusion packages to version 29.1.35

### DIFF
--- a/source/Transmittal.Desktop/Transmittal.Desktop.csproj
+++ b/source/Transmittal.Desktop/Transmittal.Desktop.csproj
@@ -73,8 +73,8 @@
 	  
     <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
 	  
-    <PackageReference Include="Syncfusion.SfGrid.WPF" Version="24.2.7" />
-    <PackageReference Include="Syncfusion.Tools.WPF" Version="24.2.7" />
+    <PackageReference Include="Syncfusion.SfGrid.WPF" Version="29.1.35" />
+    <PackageReference Include="Syncfusion.Tools.WPF" Version="29.1.35" />
 
 	  <!--IOC-->
 	  <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" />


### PR DESCRIPTION
Update Syncfusion packages to version 29.1.35

Upgraded `Syncfusion.SfGrid.WPF` and `Syncfusion.Tools.WPF`
from version `24.2.7` to `29.1.35` in the project file
`Transmittal.Desktop.csproj`. Removed references to the
older package versions.