### PR TITLE
Validate companyname is new

### DIFF
--- a/source/Transmittal.Desktop/ViewModels/NewCompanyViewModel.cs
+++ b/source/Transmittal.Desktop/ViewModels/NewCompanyViewModel.cs
@@ -1,23 +1,28 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.ComponentModel.DataAnnotations;
-using Transmittal.Library.Models;
-using Transmittal.Library.ViewModels;
 using Transmittal.Desktop.Requesters;
+using Transmittal.Library.Models;
+using Transmittal.Library.Services;
+using Transmittal.Library.Validation;
+using Transmittal.Library.ViewModels;
 
 namespace Transmittal.Desktop.ViewModels
 {
-    public partial class NewCompanyViewModel : BaseViewModel
+    public partial class NewCompanyViewModel : BaseViewModel, IHasContactDirectoryService
     {
         private readonly ICompanyRequester _callingViewModel;
+        private readonly IContactDirectoryService _contactDirectoryService = Host.GetService<IContactDirectoryService>();
 
         [ObservableProperty]
         private CompanyModel _company = new();
 
         [ObservableProperty]
         [NotifyDataErrorInfo]
-        [Required(ErrorMessage = "A company name is required")]
+        [CustomValidation(typeof(ValidationHelpers), nameof(ValidationHelpers.ValidateCompanyName))]
         public string _companyName;
+
+        public IContactDirectoryService ContactDirectoryService => _contactDirectoryService;
 
         public NewCompanyViewModel(ICompanyRequester caller)
         {
@@ -26,7 +31,6 @@ namespace Transmittal.Desktop.ViewModels
             this.ValidateAllProperties();
         }
 
-
         [RelayCommand]
         private void SendCompany()
         {
@@ -34,5 +38,21 @@ namespace Transmittal.Desktop.ViewModels
             _callingViewModel.CompanyComplete(Company);
             this.OnClosingRequest();
         }
+
+        //public static ValidationResult ValidateCompanyName(string value, ValidationContext context)
+        //{
+        //    if (string.IsNullOrWhiteSpace(value))
+        //        return new ValidationResult("A company name is required");
+
+        //    var instance = (NewCompanyViewModel)context.ObjectInstance;
+        //    var existingNames = instance._contactDirectoryService.GetCompanies_All()
+        //        .Select(c => c.CompanyName?.Trim().ToLowerInvariant())
+        //        .ToList();
+
+        //    if (existingNames.Contains(value.Trim().ToLowerInvariant()))
+        //        return new ValidationResult("This company name already exists.");
+
+        //    return ValidationResult.Success;
+        //}
     }
 }

--- a/source/Transmittal.Desktop/ViewModels/NewPersonViewModel.cs
+++ b/source/Transmittal.Desktop/ViewModels/NewPersonViewModel.cs
@@ -25,7 +25,7 @@ internal partial class NewPersonViewModel : BaseViewModel, ICompanyRequester
     private string _lastName;
     [ObservableProperty]
     [NotifyDataErrorInfo]
-    [Required(ErrorMessage = "At least provide an intial")]
+    [Required(ErrorMessage = "At least provide an initial")]
     [MinLength(1)]
     private string _firstName;
     [ObservableProperty]
@@ -53,6 +53,21 @@ internal partial class NewPersonViewModel : BaseViewModel, ICompanyRequester
     {
         _contactDirectoryService.CreateCompany(model);
         Companies.Add(model);
+    }
+
+    partial void OnCompanyIDChanged(int value)
+    {
+        this.ValidateAllProperties();
+    }
+
+    partial void OnLastNameChanged(string value)
+    {
+        this.ValidateAllProperties();
+    }
+
+    partial void OnFirstNameChanged(string value)
+    {
+        this.ValidateAllProperties();
     }
 
     [RelayCommand]

--- a/source/Transmittal.Library/Models/PersonModel.cs
+++ b/source/Transmittal.Library/Models/PersonModel.cs
@@ -16,7 +16,7 @@ public partial class PersonModel : ObservableValidator
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(FullName), nameof(FullNameReversed))]
     [NotifyDataErrorInfo]
-    [Required(ErrorMessage = "At least provide an intial")]
+    [Required(ErrorMessage = "At least provide an initial")]
     [MinLength(1)]
     private string _firstName = String.Empty;
     /// <summary>

--- a/source/Transmittal.Library/Services/IHasContactDirectoryService.cs
+++ b/source/Transmittal.Library/Services/IHasContactDirectoryService.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Transmittal.Library.Services;
+public interface IHasContactDirectoryService
+{
+    IContactDirectoryService ContactDirectoryService { get; }
+}

--- a/source/Transmittal.Library/Validation/ValidationHelpers.cs
+++ b/source/Transmittal.Library/Validation/ValidationHelpers.cs
@@ -1,0 +1,35 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Transmittal.Library.Models;
+using Transmittal.Library.Services;
+
+namespace Transmittal.Library.Validation;
+public static class ValidationHelpers
+{
+    public static ValidationResult ValidateCompanyName(string value, ValidationContext context)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return new ValidationResult("A company name is required");
+
+        // You may need to get the service from the context or pass it in
+        var instance = context.ObjectInstance;
+        var service = (IContactDirectoryService?)context.GetService(typeof(IContactDirectoryService));
+
+        if (service == null && instance is IHasContactDirectoryService hasService)
+        {
+            service = hasService.ContactDirectoryService;
+        }            
+
+        if (service != null)
+        {
+            var existingNames = service.GetCompanies_All()
+                .Select(c => c.CompanyName?.Trim().ToLowerInvariant())
+                .ToList();
+
+            if (existingNames.Contains(value.Trim().ToLowerInvariant()))
+                return new ValidationResult("This company name already exists.");
+        }
+
+        return ValidationResult.Success;
+    }
+
+}

--- a/source/Transmittal/ViewModels/NewCompanyViewModel.cs
+++ b/source/Transmittal/ViewModels/NewCompanyViewModel.cs
@@ -2,6 +2,8 @@
 using CommunityToolkit.Mvvm.Input;
 using System.ComponentModel.DataAnnotations;
 using Transmittal.Library.Models;
+using Transmittal.Library.Services;
+using Transmittal.Library.Validation;
 using Transmittal.Library.ViewModels;
 using Transmittal.Requesters;
 
@@ -10,14 +12,17 @@ namespace Transmittal.ViewModels;
 public partial class NewCompanyViewModel : BaseViewModel
 {
     private readonly ICompanyRequester _callingViewModel;
+    private readonly IContactDirectoryService _contactDirectoryService = Host.GetService<IContactDirectoryService>();
 
     [ObservableProperty]
     private CompanyModel _company = new();
 
     [ObservableProperty]
     [NotifyDataErrorInfo]
-    [Required(ErrorMessage = "A company name is required")]
+    [CustomValidation(typeof(ValidationHelpers), nameof(ValidationHelpers.ValidateCompanyName))]
     public string _companyName;
+
+    public IContactDirectoryService ContactDirectoryService => _contactDirectoryService;
 
     public NewCompanyViewModel(ICompanyRequester caller)
     {
@@ -25,7 +30,6 @@ public partial class NewCompanyViewModel : BaseViewModel
 
         this.ValidateAllProperties();
     }
-
 
     [RelayCommand]
     private void SendCompany()

--- a/source/Transmittal/ViewModels/NewPersonViewModel.cs
+++ b/source/Transmittal/ViewModels/NewPersonViewModel.cs
@@ -24,7 +24,7 @@ internal partial class NewPersonViewModel : BaseViewModel, ICompanyRequester
     private string _lastName;
     [ObservableProperty]
     [NotifyDataErrorInfo]
-    [Required(ErrorMessage = "At least provide an intial")]
+    [Required(ErrorMessage = "At least provide an initial")]
     [MinLength(1)]
     private string _firstName;
     [ObservableProperty]


### PR DESCRIPTION
#### PR Classification
Enhancement of validation and service access in view models.

#### PR Summary
This pull request implements a new interface for accessing contact directory services and enhances validation mechanisms across multiple view models. Key changes include:
- `NewCompanyViewModel`: Implements `IHasContactDirectoryService`, updates company name validation to a custom method.
- `NewPersonViewModel`: Corrects validation message for first name and adds partial methods for property change validation.
- `PersonModel`: Fixes validation message for first name.
- `IHasContactDirectoryService`: Introduces a new interface for accessing `IContactDirectoryService`.
- `ValidationHelpers`: Adds a static method for validating company names against existing entries.
