### PR TITLE
Add Topmost attribute to ProgressView window

### DIFF
--- a/source/Transmittal/Views/ProgressView.xaml
+++ b/source/Transmittal/Views/ProgressView.xaml
@@ -9,7 +9,7 @@
         d:DataContext="{d:DesignInstance viewModels:ProgressViewModel, IsDesignTimeCreatable=True}"
         WindowStartupLocation="CenterScreen" 
         Height="300" Width="600" 
-        WindowStyle="None" ResizeMode="NoResize">
+        WindowStyle="None" ResizeMode="NoResize" Topmost="True">
     
     <Window.DataContext>
         <viewModels:ProgressViewModel />


### PR DESCRIPTION
Add Topmost attribute to ProgressView window

This change adds the `Topmost="True"` attribute to the `<Window>` element in `ProgressView.xaml`, ensuring that the window remains on top of all other windows. The existing `WindowStyle` and `ResizeMode` attributes are unchanged.