### PR TITLE
Initialize CompanyID if Companies are available

### DIFF
--- a/source/Transmittal.Desktop/ViewModels/NewPersonViewModel.cs
+++ b/source/Transmittal.Desktop/ViewModels/NewPersonViewModel.cs
@@ -47,6 +47,11 @@ internal partial class NewPersonViewModel : BaseViewModel, ICompanyRequester
         this.ValidateAllProperties();
 
         Companies = new ObservableCollection<CompanyModel>(_contactDirectoryService.GetCompanies_All());
+
+        if (Companies.Any())
+        {
+            CompanyID = Companies.First().ID;
+        }
     }
 
     public void CompanyComplete(CompanyModel model)

--- a/source/Transmittal/ViewModels/NewPersonViewModel.cs
+++ b/source/Transmittal/ViewModels/NewPersonViewModel.cs
@@ -46,6 +46,11 @@ internal partial class NewPersonViewModel : BaseViewModel, ICompanyRequester
         this.ValidateAllProperties();
 
         Companies = new ObservableCollection<CompanyModel>(_contactDirectoryService.GetCompanies_All());
+
+        if (Companies.Any())
+        {
+            CompanyID = Companies.First().ID;
+        }
     }
 
     public void CompanyComplete(CompanyModel model)


### PR DESCRIPTION
Initialize CompanyID if Companies are available

Added a check to populate the CompanyID property with the ID
of the first company in the Companies collection, ensuring
it is initialized with a valid value when companies are present.

closes #130