### PR TITLE
Expand project handling in Build.Sign.cs

### DIFF
--- a/build/Build.Sign.cs
+++ b/build/Build.Sign.cs
@@ -20,7 +20,9 @@ partial class Build
 
             //var project = Solution.Transmittal;
 
-            foreach (var project in Solution.AllProjects.Where(project => project == Solution.Transmittal || project == Solution.Transmittal_Desktop))
+            foreach (var project in Solution.AllProjects.Where(project => project == Solution.Transmittal || 
+            project == Solution.Transmittal_Desktop || 
+            project == Solution.Transmittal_Analytics_TrayApp))
             {
                 AbsolutePath projectDirectory = project.Directory;
                 Log.Information(projectDirectory);


### PR DESCRIPTION
Expand project handling in Build.Sign.cs

Added condition to include Solution.Transmittal_Analytics_TrayApp in the foreach loop iterating over Solution.AllProjects, enhancing the scope of projects processed.