### PR TITLE
Add analytics feature with usage tracking support

### DIFF
--- a/source/Transmittal.Desktop/Host.cs
+++ b/source/Transmittal.Desktop/Host.cs
@@ -6,6 +6,7 @@ using Serilog;
 using Serilog.Events;
 using Serilog.Formatting.Json;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using System.Runtime.Versioning;
 using Transmittal.Desktop.Services;
@@ -20,21 +21,48 @@ internal static class Host
     public static async Task StartHost()
     {
         var logPath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "Transmittal", "Transmittal_Log.json");
+        var analyticsSettings = Transmittal.Library.Helpers.AnalyticsSettingsLoader.LoadAnalyticsSettings();
 
 #if DEBUG
         logPath = "log.json";
 #endif
-
-        Log.Logger = new LoggerConfiguration()
+        var loggerConfigTransmittal = new LoggerConfiguration()
             .Enrich.FromLogContext()
+            .Enrich.WithProperty("ApplicationVersion", System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString())
             .MinimumLevel.Debug()
             .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
             .WriteTo.Debug(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
-            .WriteTo.File(new JsonFormatter(), logPath,
-                restrictedToMinimumLevel: LogEventLevel.Information,
-                rollingInterval: RollingInterval.Day,
-                retainedFileCountLimit: 7)
-            .CreateLogger();
+
+            // Local file - exclude usage tracking logs
+            .WriteTo.Logger(l => l
+                .Filter.ByExcluding(le => le.Properties.ContainsKey("UsageTracking"))
+                .WriteTo.File(new JsonFormatter(), logPath,
+                    restrictedToMinimumLevel: LogEventLevel.Warning,
+                    rollingInterval: RollingInterval.Day,
+                    retainedFileCountLimit: 7));
+
+        if (analyticsSettings.EnableAnalytics)
+        {
+            // Usage tracking enabled, write to specified path
+            var usageLogPath = analyticsSettings.AnalyticsPath;
+
+            if (Directory.Exists(usageLogPath))
+            {
+                var userName = Environment.UserName.Replace("\\", "_").Replace("/", "_");
+                var machineName = Environment.MachineName.Replace("\\", "_").Replace("/", "_");
+                var usageLogFilePath = Path.Combine(usageLogPath, $"Transmittal_{userName}_{machineName}_.json");
+
+                loggerConfigTransmittal = loggerConfigTransmittal
+                .WriteTo.Logger(l => l
+                    .Filter.ByIncludingOnly(le => le.Properties.ContainsKey("UsageTracking"))
+                    .WriteTo.Async(a => a.File(new JsonFormatter(), usageLogFilePath,
+                        restrictedToMinimumLevel: LogEventLevel.Information,
+                        rollingInterval: RollingInterval.Month,
+                        retainedFileCountLimit: 2), 1000));
+            }
+        }
+
+        Log.Logger = loggerConfigTransmittal.CreateLogger();
 
         _host = Microsoft.Extensions.Hosting.Host
         .CreateDefaultBuilder()
@@ -56,11 +84,11 @@ internal static class Host
         .ConfigureServices((_, services) =>
         {
             // Properly configure logging
-            services.AddLogging(builder =>
-            {
-                builder.ClearProviders();
-                builder.AddSerilog(Log.Logger);
-            });
+            //services.AddLogging(builder =>
+            //{
+            //    builder.ClearProviders();
+            //    builder.AddSerilog(Log.Logger);
+            //});
 
             services.AddSingleton<ISettingsService, SettingsService>();
             services.AddSingleton<ISoftwareUpdateService, SoftwareUpdateService>();

--- a/source/Transmittal.Desktop/Transmittal.Desktop.csproj
+++ b/source/Transmittal.Desktop/Transmittal.Desktop.csproj
@@ -83,6 +83,7 @@
 	  <PackageReference Include="Serilog.Sinks.Debug" Version="3.*" />
 	  <PackageReference Include="Serilog.Sinks.File" Version="6.*" />
 	  <PackageReference Include="Serilog.Extensions.Hosting" Version="8.*" />
+	  <PackageReference Include="Serilog.Sinks.Async" Version="2.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Transmittal.Desktop/ViewModels/ArchiveViewModel.cs
+++ b/source/Transmittal.Desktop/ViewModels/ArchiveViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Extensions.Logging;
+using Serilog.Context;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -195,6 +196,11 @@ internal partial class ArchiveViewModel : BaseViewModel, IPackageRequester
     [RelayCommand]
     private void MergeTransmittals()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(MergeTransmittalsCommand));
+        }
+
         List<TransmittalModel> transmittalsToMerge = SelectedTransmittals.Cast<TransmittalModel>().ToList();
         //remove the selected items from the list
         foreach (TransmittalModel item in transmittalsToMerge)
@@ -210,6 +216,11 @@ internal partial class ArchiveViewModel : BaseViewModel, IPackageRequester
     [RelayCommand]
     private void DuplicateTransmittal()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(DuplicateTransmittalCommand));
+        }
+
         TransmittalModel transmittalModel = SelectedTransmittals.First() as TransmittalModel;
         TransmittalModel newTransmittal = new();
 
@@ -246,6 +257,11 @@ internal partial class ArchiveViewModel : BaseViewModel, IPackageRequester
     [RelayCommand]
     private void DeleteTransmittal()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(DeleteTransmittalCommand));
+        }
+
         TransmittalModel transmittalModel = SelectedTransmittals.First() as TransmittalModel;
 
         if (transmittalModel.Items.Count == 0 &&
@@ -259,6 +275,11 @@ internal partial class ArchiveViewModel : BaseViewModel, IPackageRequester
     [RelayCommand]
     private void ShowSummaryReport()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(ShowSummaryReportCommand));
+        }
+
         Reports.Reports reports = new(_settingsService, _contactDirectoryService, _transmittalService);
         reports.ShowTransmittalSummaryReport();
     }
@@ -266,6 +287,11 @@ internal partial class ArchiveViewModel : BaseViewModel, IPackageRequester
     [RelayCommand]
     private void ShowSummaryRangeReport()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(ShowSummaryRangeReportCommand));
+        }
+
         Reports.Reports reports = new(_settingsService, _contactDirectoryService, _transmittalService);
         reports.ShowTransmittalSummaryReport(SelectedTransmittals.Cast<TransmittalModel>().ToList());
     }
@@ -273,6 +299,11 @@ internal partial class ArchiveViewModel : BaseViewModel, IPackageRequester
     [RelayCommand]
     private void ShowTransmittalReport()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(ShowTransmittalReportCommand));
+        }
+
         TransmittalModel transmittalModel = SelectedTransmittals.First() as TransmittalModel;
         Reports.Reports reports = new(_settingsService, _contactDirectoryService, _transmittalService);
         reports.ShowTransmittalReport(transmittalModel.ID);
@@ -281,6 +312,11 @@ internal partial class ArchiveViewModel : BaseViewModel, IPackageRequester
     [RelayCommand]
     private void MasterDocumentsListReport()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(MasterDocumentsListReportCommand));
+        }
+
         Reports.Reports reports = new(_settingsService, _contactDirectoryService, _transmittalService);
         reports.ShowMasterDocumentsListReport();
     }
@@ -288,6 +324,11 @@ internal partial class ArchiveViewModel : BaseViewModel, IPackageRequester
     [RelayCommand]
     private void DeleteSelectedTransmittalItem()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(DeleteSelectedTransmittalItemCommand));
+        }
+
         foreach (var item in SelectedTransmittalItems)
         {
             _transmittalService.DeleteTransmittalItem((TransmittalItemModel)item);
@@ -300,6 +341,11 @@ internal partial class ArchiveViewModel : BaseViewModel, IPackageRequester
     [RelayCommand]
     private void DeleteSelectedDistribution()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(DeleteSelectedDistributionCommand));
+        }
+
         foreach (var item in SelectedTransmittalDistributions)
         {
             _transmittalService.DeleteTransmittalDist((TransmittalDistributionModel)item);

--- a/source/Transmittal.Desktop/ViewModels/DirectoryViewModel.cs
+++ b/source/Transmittal.Desktop/ViewModels/DirectoryViewModel.cs
@@ -1,6 +1,8 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using Serilog.Context;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -16,6 +18,7 @@ internal partial class DirectoryViewModel : BaseViewModel
     private readonly ISettingsService _settingsService = Host.GetService<ISettingsService>();
     private readonly IContactDirectoryService _contactDirectoryService = Host.GetService<IContactDirectoryService>();
     private readonly ITransmittalService _transmittalService = Host.GetService<ITransmittalService>();
+    private readonly ILogger<DirectoryViewModel> _logger = Host.GetService<ILogger<DirectoryViewModel>>();
 
     public string WindowTitle { get; private set; }
 
@@ -165,6 +168,11 @@ internal partial class DirectoryViewModel : BaseViewModel
     [RelayCommand]
     private void RemovePerson()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(RemovePersonCommand));
+        }
+
         if (SelectedPerson != null)
         {
             if (_transmittalService.GetTransmittals_ByPerson(SelectedPerson.ID).Count == 0)
@@ -177,6 +185,11 @@ internal partial class DirectoryViewModel : BaseViewModel
     [RelayCommand]
     private void RemoveCompany()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(RemoveCompanyCommand));
+        }
+
         if (SelectedCompany != null)
         {
             if (_contactDirectoryService.GetPeople_ByCompany(SelectedCompany.ID).Count == 0)
@@ -189,6 +202,11 @@ internal partial class DirectoryViewModel : BaseViewModel
     [RelayCommand]
     private void ExportVCard()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(ExportVCardCommand));
+        }
+
         ProjectDirectoryModel projectDirectoryModel = new()
         {
             Person = SelectedPerson,
@@ -201,6 +219,11 @@ internal partial class DirectoryViewModel : BaseViewModel
     [RelayCommand]
     private void ShowDirectoryReport()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(ShowDirectoryReportCommand));
+        }
+
         BuildProjectDirectory();
 
         Reports.Reports reports = new(_settingsService, 
@@ -213,6 +236,11 @@ internal partial class DirectoryViewModel : BaseViewModel
     [RelayCommand]
     private void ShowTransmittalHistoryReport()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        {
+            _logger.LogInformation("{command}", nameof(ShowTransmittalHistoryReportCommand));
+        }
+
         Reports.Reports reports = new(_settingsService,
             _contactDirectoryService,
             _transmittalService);

--- a/source/Transmittal.Desktop/Views/MainView.xaml.cs
+++ b/source/Transmittal.Desktop/Views/MainView.xaml.cs
@@ -1,4 +1,6 @@
-﻿using Ookii.Dialogs.Wpf;
+﻿using Microsoft.Extensions.Logging;
+using Ookii.Dialogs.Wpf;
+using Serilog.Context;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
@@ -14,6 +16,7 @@ namespace Transmittal.Desktop.Views
     {
         private readonly ViewModels.MainViewModel _viewModel;
         private readonly ISettingsService _settingsService = Host.GetService<ISettingsService>();
+        private readonly ILogger<MainView> _logger = Host.GetService<ILogger<MainView>>();
 
         public MainView()
         {
@@ -32,30 +35,55 @@ namespace Transmittal.Desktop.Views
 
         private void Button_Transmittal_Click(object sender, RoutedEventArgs e)
         {
+            using (LogContext.PushProperty("UsageTracking", true))
+            {
+                _logger.LogInformation("{command}", nameof(Button_Transmittal_Click));
+            }
+
             TransmittalView view = new();
             view.ShowDialog();
         }
 
         private void Button_TransmittalArchive_Click(object sender, RoutedEventArgs e)
         {
+            using (LogContext.PushProperty("UsageTracking", true))
+            {
+                _logger.LogInformation("{command}", nameof(Button_TransmittalArchive_Click));
+            }
+
             ArchiveView view = new();
             view.ShowDialog();
         }
 
         private void Button_Directory_Click(object sender, RoutedEventArgs e)
         {
+            using (LogContext.PushProperty("UsageTracking", true))
+            {
+                _logger.LogInformation("{command}", nameof(Button_Directory_Click));
+            }
+
             DirectoryView view = new();
             view.ShowDialog();
         }
 
         private void Button_About_Click(object sender, RoutedEventArgs e)
         {
+           using (LogContext.PushProperty("UsageTracking", true))
+           {
+                _logger.LogInformation("{command}", nameof(Button_About_Click));
+           }
+
             AboutView view = new AboutView();
             view.ShowDialog();
         }
 
         private void Button_Settings_Click(object sender, RoutedEventArgs e)
         {
+           using (LogContext.PushProperty("UsageTracking", true))
+           {
+                _logger.LogInformation("{command}", nameof(Button_Settings_Click));
+           }
+
             SettingsView view = new();
             view.ShowDialog();
         }

--- a/source/Transmittal.Library/AnalyticsSettings.json
+++ b/source/Transmittal.Library/AnalyticsSettings.json
@@ -1,0 +1,4 @@
+﻿{
+  "EnableAnalytics" :  true,
+  "AnalyticsPath" :  ""
+}

--- a/source/Transmittal.Library/Helpers/AnalyticsSettingsLoader.cs
+++ b/source/Transmittal.Library/Helpers/AnalyticsSettingsLoader.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Transmittal.Library.Models;
+
+namespace Transmittal.Library.Helpers;
+public static class AnalyticsSettingsLoader
+{
+    public static AnalyticsSettings LoadAnalyticsSettings()
+    {
+#if DEBUG
+        //look for the optional analytics settings file
+        var analyticsFile = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location),
+            "AnalyticsSettings.json");
+#else
+        //look for the optional analytics settings file
+        var analyticsFile = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+            "Transmittal",
+            "AnalyticsSettings.json");
+#endif
+
+        if (File.Exists(analyticsFile))
+        {
+            Debug.Write($"Loading optional analytics settings from {analyticsFile}");
+
+            var settingsJson = File.ReadAllText(analyticsFile, Encoding.UTF8);
+
+            if (settingsJson is not null)
+            {
+                try
+                {
+                    var analyticsSettings = System.Text.Json.JsonSerializer.Deserialize<AnalyticsSettings>(settingsJson)!;
+#if DEBUG
+                    if (analyticsSettings.EnableAnalytics & string.IsNullOrEmpty(analyticsSettings.AnalyticsPath))
+                    {
+                        analyticsSettings.AnalyticsPath = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location));
+                    }
+#endif
+
+                    Debug.Write("Optional analytics settings loaded successfully.");
+
+                    return analyticsSettings;
+                }
+                catch (Exception ex)
+                {
+                    Debug.Write(ex, "Error deserializing settings file.");
+                }
+            }
+
+        }
+
+        // If the file doesn't exist or deserialization fails, return default settings which disables analytics
+        return new AnalyticsSettings();
+    }
+}

--- a/source/Transmittal.Library/Models/AnalyticsSettings.cs
+++ b/source/Transmittal.Library/Models/AnalyticsSettings.cs
@@ -1,0 +1,19 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Transmittal.Library.Models;
+
+    // optional settings used for internal analytics logging.
+    // requires the user to opt in with a separate AnalyticsSettings.json
+public partial class AnalyticsSettings : ObservableValidator
+{
+    [ObservableProperty]
+    private bool _enableAnalytics = false;
+
+    [ObservableProperty]
+    private string _analyticsPath = string.Empty;
+}

--- a/source/Transmittal.Library/Transmittal.Library.csproj
+++ b/source/Transmittal.Library/Transmittal.Library.csproj
@@ -35,5 +35,11 @@
 	<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="AnalyticsSettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>
 

--- a/source/Transmittal/Commands/CommandAbout.cs
+++ b/source/Transmittal/Commands/CommandAbout.cs
@@ -1,7 +1,9 @@
 ﻿using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Microsoft.Extensions.Logging;
 using Nice3point.Revit.Toolkit.External;
+using Serilog.Context;
 using System.Diagnostics;
 
 namespace Transmittal.Commands;
@@ -9,8 +11,14 @@ namespace Transmittal.Commands;
 [Transaction(TransactionMode.Manual)]
 internal class CommandAbout : ExternalCommand
 {
+    private readonly ILogger<CommandAbout> _logger = Host.GetService<ILogger<CommandAbout>>();
     public override void Execute()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        using (LogContext.PushProperty("RevitVersion", App.CtrApp.VersionNumber))
+        {
+            _logger.LogInformation("{command}", nameof(CommandAbout));
+        }
 
 #if DEBUG
         var currentPath = System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);

--- a/source/Transmittal/Commands/CommandDirectory.cs
+++ b/source/Transmittal/Commands/CommandDirectory.cs
@@ -1,8 +1,10 @@
 ﻿using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Microsoft.Extensions.Logging;
 using Nice3point.Revit.Toolkit;
 using Nice3point.Revit.Toolkit.External;
+using Serilog.Context;
 using System.Diagnostics;
 using Transmittal.Library.Services;
 using Transmittal.Services;
@@ -12,13 +14,17 @@ namespace Transmittal.Commands;
 [Transaction(TransactionMode.Manual)]
 internal class CommandDirectory : ExternalCommand
 {
-    private ISettingsServiceRvt _settingsServiceRvt;
-    private ISettingsService _settingsService;
+    private readonly ILogger<CommandDirectory> _logger = Host.GetService<ILogger<CommandDirectory>>();
+    private readonly ISettingsServiceRvt _settingsServiceRvt = Host.GetService<ISettingsServiceRvt>();
+    private readonly ISettingsService _settingsService = Host.GetService<ISettingsService>();
 
     public override void Execute()
     {
-        _settingsServiceRvt = Host.GetService<ISettingsServiceRvt>();
-        _settingsService = Host.GetService<ISettingsService>();
+        using (LogContext.PushProperty("UsageTracking", true))
+        using (LogContext.PushProperty("RevitVersion", App.CtrApp.VersionNumber))
+        {
+            _logger.LogInformation("{command}", nameof(CommandDirectory));
+        }
 
         App.CachedUiApp = Context.UiApplication;
         App.RevitDocument = Context.ActiveDocument;

--- a/source/Transmittal/Commands/CommandImportSettings.cs
+++ b/source/Transmittal/Commands/CommandImportSettings.cs
@@ -2,9 +2,11 @@
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.Extensions.Logging;
 using Nice3point.Revit.Toolkit;
 using Nice3point.Revit.Toolkit.External;
 using Ookii.Dialogs.Wpf;
+using Serilog.Context;
 using System.IO;
 using System.Text.Json;
 using Transmittal.Library.Models;
@@ -16,8 +18,15 @@ namespace Transmittal.Commands;
 [Transaction(TransactionMode.Manual)]
 internal class CommandImportSettings : ExternalCommand
 {
+    private readonly ILogger<CommandImportSettings> _logger = Host.GetService<ILogger<CommandImportSettings>>();
+
     public override void Execute()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        using (LogContext.PushProperty("RevitVersion", App.CtrApp.VersionNumber))
+        {
+            _logger.LogInformation("{command}", nameof(CommandImportSettings));
+        }
 
         App.CachedUiApp = Context.UiApplication;
         App.RevitDocument = Context.ActiveDocument;

--- a/source/Transmittal/Commands/CommandSettings.cs
+++ b/source/Transmittal/Commands/CommandSettings.cs
@@ -1,8 +1,10 @@
 ﻿using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Microsoft.Extensions.Logging;
 using Nice3point.Revit.Toolkit;
 using Nice3point.Revit.Toolkit.External;
+using Serilog.Context;
 using Transmittal.Services;
 
 namespace Transmittal.Commands;
@@ -10,8 +12,16 @@ namespace Transmittal.Commands;
 [Transaction(TransactionMode.Manual)]
 internal class CommandSettings : ExternalCommand
 {
+    private readonly ILogger<CommandSettings> _logger = Host.GetService<ILogger<CommandSettings>>();
+
     public override void Execute()
     {
+        using (LogContext.PushProperty("UsageTracking", true))
+        using (LogContext.PushProperty("RevitVersion", App.CtrApp.VersionNumber))
+        {
+            _logger.LogInformation("{command}", nameof(CommandSettings));
+        }
+
         App.CachedUiApp = Context.UiApplication;
         App.RevitDocument = Context.ActiveDocument;
 

--- a/source/Transmittal/Commands/CommandTransmittal.cs
+++ b/source/Transmittal/Commands/CommandTransmittal.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Nice3point.Revit.Toolkit;
 using Nice3point.Revit.Toolkit.External;
+using Serilog.Context;
 using System.Diagnostics;
 using Transmittal.Library.Services;
 using Transmittal.Services;
@@ -14,13 +15,16 @@ namespace Transmittal.Commands;
 [Transaction(TransactionMode.Manual)]
 public class CommandTransmittal : ExternalCommand
 {
-    private ISettingsServiceRvt _settingsServiceRvt;
-    private ILogger<CommandTransmittal> _logger;
+    private readonly ISettingsServiceRvt _settingsServiceRvt = Host.GetService<ISettingsServiceRvt>();
+    private readonly ILogger<CommandTransmittal> _logger = Host.GetService<ILogger<CommandTransmittal>>();
 
     public override void Execute()
-    {       
-        _settingsServiceRvt = Host.GetService<ISettingsServiceRvt>();
-        _logger = Host.GetService<ILogger<CommandTransmittal>>();
+    {
+        using (LogContext.PushProperty("UsageTracking", true))
+        using (LogContext.PushProperty("RevitVersion", App.CtrApp.VersionNumber))
+        {
+            _logger.LogInformation("{command}", nameof(CommandTransmittal));
+        }
 
         App.CachedUiApp = Context.UiApplication;
         App.RevitDocument = Context.ActiveDocument;

--- a/source/Transmittal/Commands/CommandTransmittalsArchive.cs
+++ b/source/Transmittal/Commands/CommandTransmittalsArchive.cs
@@ -1,8 +1,10 @@
 ﻿using Autodesk.Revit.Attributes;
 using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
+using Microsoft.Extensions.Logging;
 using Nice3point.Revit.Toolkit;
 using Nice3point.Revit.Toolkit.External;
+using Serilog.Context;
 using System.Diagnostics;
 using Transmittal.Library.Services;
 using Transmittal.Services;
@@ -12,13 +14,17 @@ namespace Transmittal.Commands;
 [Transaction(TransactionMode.Manual)]
 internal class CommandTransmittalsArchive : ExternalCommand
 {
-    private ISettingsServiceRvt _settingsServiceRvt;
-    private ISettingsService _settingsService;
+    private readonly ISettingsServiceRvt _settingsServiceRvt = Host.GetService<ISettingsServiceRvt>();
+    private readonly ISettingsService _settingsService = Host.GetService<ISettingsService>();
+    private readonly ILogger<CommandTransmittalsArchive> _logger = Host.GetService<ILogger<CommandTransmittalsArchive>>();
 
     public override void Execute()
     {
-        _settingsServiceRvt = Host.GetService<ISettingsServiceRvt>();
-        _settingsService = Host.GetService<ISettingsService>();
+        using (LogContext.PushProperty("UsageTracking", true))
+        using (LogContext.PushProperty("RevitVersion", App.CtrApp.VersionNumber))
+        {
+            _logger.LogInformation("{command}", nameof(CommandTransmittalsArchive));
+        }
 
         App.CachedUiApp = Context.UiApplication;
         App.RevitDocument = Context.ActiveDocument;

--- a/source/Transmittal/Transmittal.csproj
+++ b/source/Transmittal/Transmittal.csproj
@@ -114,6 +114,8 @@
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="8.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
 		<PackageReference Include="Serilog.Sinks.Debug" Version="3.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
 		<PackageReference Include="Serilog.Sinks.File" Version="6.*" Condition="'$(TargetFramework)' == 'net8.0-windows'" />
+
+		<PackageReference Include="Serilog.Sinks.Async" Version="2.*" />
 		
 		<!--Repacking-->
 		<PackageReference Include="ILRepack" Version="2.0.41">

--- a/source/Transmittal/ViewModels/TransmittalViewModel.cs
+++ b/source/Transmittal/ViewModels/TransmittalViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Microsoft.Extensions.Logging;
 using Nice3point.Revit.Extensions;
+using Serilog.Context;
 using Syncfusion.XlsIO;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;


### PR DESCRIPTION
Add analytics feature with usage tracking support

This commit introduces an optional analytics feature to the application, allowing users to enable or disable usage tracking via an `AnalyticsSettings.json` file. The new `AnalyticsSettingsLoader` class is implemented to load these settings, and various application components are updated to log usage information for specific commands. Additionally, the logging configuration is enhanced to separate usage tracking logs from other logs, ensuring relevant information is recorded based on user preferences.