### PR TITLE
Enhance logging with user and machine information

### DIFF
--- a/source/Transmittal.Desktop/Host.cs
+++ b/source/Transmittal.Desktop/Host.cs
@@ -26,8 +26,13 @@ internal static class Host
 #if DEBUG
         logPath = "log.json";
 #endif
+        var userName = Environment.UserName.Replace("\\", "_").Replace("/", "_");
+        var machineName = Environment.MachineName.Replace("\\", "_").Replace("/", "_");
+
         var loggerConfigTransmittal = new LoggerConfiguration()
             .Enrich.FromLogContext()
+            .Enrich.WithProperty("UserDomain", userName)
+            .Enrich.WithProperty("MachineName", machineName)
             .Enrich.WithProperty("ApplicationVersion", System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString())
             .MinimumLevel.Debug()
             .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
@@ -48,8 +53,6 @@ internal static class Host
 
             if (Directory.Exists(usageLogPath))
             {
-                var userName = Environment.UserName.Replace("\\", "_").Replace("/", "_");
-                var machineName = Environment.MachineName.Replace("\\", "_").Replace("/", "_");
                 var usageLogFilePath = Path.Combine(usageLogPath, $"Transmittal_{userName}_{machineName}_.json");
 
                 loggerConfigTransmittal = loggerConfigTransmittal

--- a/source/Transmittal/Host.cs
+++ b/source/Transmittal/Host.cs
@@ -24,8 +24,13 @@ internal static class Host
         logPath = "log.json";
 #endif
 
+        var userName = Environment.UserName.Replace("\\", "_").Replace("/", "_");
+        var machineName = Environment.MachineName.Replace("\\", "_").Replace("/", "_");
+
         var loggerConfigTransmittal = new LoggerConfiguration()
             .Enrich.FromLogContext()
+            .Enrich.WithProperty("UserDomain", userName)
+            .Enrich.WithProperty("MachineName", machineName)
             .Enrich.WithProperty("ApplicationVersion", System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString())
             .MinimumLevel.Debug()
             .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
@@ -46,8 +51,7 @@ internal static class Host
 
             if (Directory.Exists(usageLogPath))
             {
-                var userName = Environment.UserName.Replace("\\", "_").Replace("/", "_");
-                var machineName = Environment.MachineName.Replace("\\", "_").Replace("/", "_");
+
                 var usageLogFilePath = Path.Combine(usageLogPath, $"Transmittal_{userName}_{machineName}_.json");
 
                 loggerConfigTransmittal = loggerConfigTransmittal


### PR DESCRIPTION
Enhance logging with user and machine information

Added user and machine name properties to the logging configuration in the `Host` class. Removed previous declarations of these properties from the usage tracking block and constructed a new `usageLogFilePath` using the enriched properties. This improves the logging context while preserving usage tracking functionality.