### PR TITLE
Update document saving in CommandTransmittal class

### DIFF
--- a/source/Transmittal/Commands/CommandTransmittal.cs
+++ b/source/Transmittal/Commands/CommandTransmittal.cs
@@ -43,7 +43,7 @@ public class CommandTransmittal : ExternalCommand
             var taskDialogResult = td.Show();
             if (taskDialogResult == TaskDialogResult.CommandLink1)
             {
-                App.CachedUiApp.ActiveUIDocument.Document.Save();
+                App.RevitDocument.Save();
             }
             else if (taskDialogResult == TaskDialogResult.CommandLink2)
             {


### PR DESCRIPTION
Update document saving in CommandTransmittal class

Changed the document saving method from using the active UI document to directly saving the Revit document. This adjustment may improve how the application manages document saving during command execution.

closes #145