### PR TITLE
Add revision editing checks and reintroduce methods

### DIFF
--- a/source/Transmittal/Views/RevisionsView.xaml.cs
+++ b/source/Transmittal/Views/RevisionsView.xaml.cs
@@ -52,6 +52,12 @@ public partial class RevisionsView : Window
 
     private void ButtonAddRevision_Click(object sender, RoutedEventArgs e)
     {
+        if(_viewModel.CanEditRevisions() == false)
+        {
+            return;
+        }
+
+
         Views.NewRevisionView dialog = new Views.NewRevisionView(_viewModel);
         dialog.Owner = this;
         dialog.ShowDialog();


### PR DESCRIPTION
Add revision editing checks and reintroduce methods

- Implemented `CanEditRevisions` to determine if the user can edit revisions based on worksharing settings.
- Reintroduced `LoadRevisions` to clear and load revisions from the Revit document.
- Added `Revisions_CollectionChanged` method with a placeholder for future implementation.
- Updated `ButtonAddRevision_Click` to check edit permissions before allowing new revision dialog.

closes #84 