### PR TITLE
Update version and enhance analytics with CountryId

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Company>Russell Green</Company>
 
-    <VersionPrefix>3.5.1</VersionPrefix>
+    <VersionPrefix>3.5.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <ApplicationVersion>$(VersionPrefix).0</ApplicationVersion>
     <FileVersion>$(VersionPrefix).0</FileVersion>

--- a/source/Transmittal.Desktop/Host.cs
+++ b/source/Transmittal.Desktop/Host.cs
@@ -66,6 +66,8 @@ internal static class Host
                 opts.GlobalParams["app_version"] = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString();
                 opts.GlobalParams["app_country"] = regionInfo.EnglishName;
                 opts.GlobalParams["app_type"] = "Desktop";
+
+                opts.CountryId = regionInfo.TwoLetterISORegionName;
             });
 
         if (analyticsSettings.EnableAnalytics)

--- a/source/Transmittal/Host.cs
+++ b/source/Transmittal/Host.cs
@@ -69,6 +69,8 @@ internal static class Host
                  opts.GlobalParams["app_country"] = regionInfo.EnglishName;
                  opts.GlobalParams["app_type"] = "Revit Addin";
                  opts.GlobalParams["revit_version"] = App.CtrApp.VersionNumber;
+
+                 opts.CountryId = regionInfo.TwoLetterISORegionName;
              });
 
         if (analyticsSettings.EnableAnalytics)


### PR DESCRIPTION
Update version and enhance analytics with CountryId

Updated `VersionPrefix` to 3.5.2 in `Directory.Build.props` to reflect a new project version.

Enhanced analytics functionality in `Host.cs` by adding `opts.CountryId`, which uses the region's two-letter ISO code. This change was applied in both general application analytics and the "Revit Addin" context to improve tracking capabilities.