### PR TITLE
Handle newer Transmittal schema versions gracefully

### DIFF
--- a/source/Transmittal.Desktop/Controls/Hyperlink.cs
+++ b/source/Transmittal.Desktop/Controls/Hyperlink.cs
@@ -32,7 +32,9 @@ public class Hyperlink : Button
     private void RequestNavigate(object sender, RoutedEventArgs eventArgs)
     {
         if (string.IsNullOrEmpty(NavigateUri))
+        {
             return;
+        }
 
         System.Diagnostics.ProcessStartInfo sInfo = new(new Uri(NavigateUri).AbsoluteUri)
         {

--- a/source/Transmittal.Desktop/Views/AboutView.xaml.cs
+++ b/source/Transmittal.Desktop/Views/AboutView.xaml.cs
@@ -21,11 +21,16 @@ public partial class AboutView : Window
 
     private void OpenLink(object sender, RoutedEventArgs e)
     {
-        if (e.OriginalSource is not Hyperlink link) return;
-
+        if (e.OriginalSource is not Hyperlink link)
+        {
+            return;
+        }
 
         var uri = link.NavigateUri;
-        if (uri == null) return;
+        if (uri == null)
+        {
+            return;
+        }
 
         var psi = new ProcessStartInfo
         {

--- a/source/Transmittal.Library/Extensions/NamingExtensions.cs
+++ b/source/Transmittal.Library/Extensions/NamingExtensions.cs
@@ -194,7 +194,9 @@ public static class NamingExtensions
     public static bool IsValidEmailAddress(this string inputString)
     {
         if (string.IsNullOrWhiteSpace(inputString))
+        {
             return false;
+        }
 
         try
         {
@@ -203,7 +205,9 @@ public static class NamingExtensions
 
             // Examines if the email is in proper form
             if (!Regex.IsMatch(inputString, @"^[^@\s]+@[^@\s]+\.[^@\s]+$", RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(250)))
+            {
                 return false;
+            }
         }
         catch (RegexMatchTimeoutException)
         {

--- a/source/Transmittal/Commands/CommandSettings.cs
+++ b/source/Transmittal/Commands/CommandSettings.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Nice3point.Revit.Toolkit;
 using Nice3point.Revit.Toolkit.External;
 using Serilog.Context;
+using Transmittal.Exceptions;
 using Transmittal.Services;
 
 namespace Transmittal.Commands;
@@ -24,7 +25,16 @@ internal class CommandSettings : ExternalCommand
         App.CachedUiApp = RevitContext.UiApplication;
         App.RevitDocument = RevitContext.ActiveDocument;
 
-        var newView = new Views.SettingsView();
-        newView.ShowDialog();
+        try
+        {
+            var newView = new Views.SettingsView();
+            newView.ShowDialog();
+        }
+        catch (SchemaVersionTooNewException ex)
+        {
+            // Newer schema detected - user needs to upgrade app, don't show settings
+            _logger.LogError(ex, "Document schema version too new");
+            return;
+        }
     }
 }

--- a/source/Transmittal/Commands/CommandTransmittal.cs
+++ b/source/Transmittal/Commands/CommandTransmittal.cs
@@ -7,6 +7,7 @@ using Nice3point.Revit.Toolkit;
 using Nice3point.Revit.Toolkit.External;
 using Serilog.Context;
 using System.Diagnostics;
+using Transmittal.Exceptions;
 using Transmittal.Library.Services;
 using Transmittal.Services;
 
@@ -57,18 +58,27 @@ public class CommandTransmittal : ExternalCommand
             // add a showdialog watcher
             App.CachedUiApp.DialogBoxShowing += AppDialogShowing;
 
-            if (_settingsServiceRvt.GetSettingsRvt(App.RevitDocument) == false)
+            try
             {
-                var settingsView = new Views.SettingsView();
-                settingsView.ShowDialog();
+                if (_settingsServiceRvt.GetSettingsRvt(App.RevitDocument) == false)
+                {
+                    var settingsView = new Views.SettingsView();
+                    settingsView.ShowDialog();
+                }
+                else
+                {
+                    var transmittalView = new Views.TransmittalView();
+                    transmittalView.ShowDialog();
+                }
             }
-            else
+            catch (SchemaVersionTooNewException ex)
             {
-                var transmittalView = new Views.TransmittalView();
-                transmittalView.ShowDialog();
+                // Newer schema detected - user needs to upgrade app, don't show settings
+                _logger.LogError(ex, "Document schema version too new");
+                return;
             }
 
-            return;            
+            return;
             
         }
         catch (Exception ex)

--- a/source/Transmittal/Exceptions/SchemaVersionTooNewException.cs
+++ b/source/Transmittal/Exceptions/SchemaVersionTooNewException.cs
@@ -1,0 +1,18 @@
+namespace Transmittal.Exceptions;
+
+/// <summary>
+/// Thrown when a Revit document contains a Transmittal schema version newer than the current application supports.
+/// This indicates the user needs to update to a newer version of the application.
+/// </summary>
+public class SchemaVersionTooNewException : Exception
+{
+    public int DocumentSchemaVersion { get; }
+    public int ApplicationSchemaVersion { get; }
+
+    public SchemaVersionTooNewException(int documentSchemaVersion, int applicationSchemaVersion)
+        : base($"Document schema version {documentSchemaVersion} is newer than application support (version {applicationSchemaVersion})")
+    {
+        DocumentSchemaVersion = documentSchemaVersion;
+        ApplicationSchemaVersion = applicationSchemaVersion;
+    }
+}

--- a/source/Transmittal/Services/SettingsServiceRvt.cs
+++ b/source/Transmittal/Services/SettingsServiceRvt.cs
@@ -2,6 +2,7 @@
 using Autodesk.Revit.DB.ExtensibleStorage;
 using Microsoft.Extensions.Logging;
 using Nice3point.Revit.Extensions;
+using Transmittal.Exceptions;
 using Transmittal.Library.DataAccess;
 using Transmittal.Library.Extensions;
 using Transmittal.Library.Models;
@@ -21,6 +22,7 @@ internal class SettingsServiceRvt : ISettingsServiceRvt
     private const string _schemaNameV3 = "TransmittalAppSettingsV3";
     private const string _schemaGuidV3 = "8D2FD527-CF54-45DB-9248-C65F6729D18B";
     private const string _vendorID = "Transmittal";
+    private const int _latestSchemaVersion = 3;
 
     // project paramaters
     private const string _projectIdentifierParamGuid = "ce8c18ee-3b90-4f42-8938-ae90e3af5a6a";
@@ -39,6 +41,7 @@ internal class SettingsServiceRvt : ISettingsServiceRvt
     private readonly ISettingsService _settingsService;
     private readonly IDataConnection _dataConnection;
     private readonly ILogger<SettingsServiceRvt> _logger;
+    private readonly IMessageBoxService _messageBox;
 
     private Schema _oldSchemaV0 = null;
     private Schema _oldSchemaV1 = null;
@@ -47,11 +50,13 @@ internal class SettingsServiceRvt : ISettingsServiceRvt
 
     public SettingsServiceRvt(IDataConnection dataConnection, 
         ISettingsService settingsService,
-        ILogger<SettingsServiceRvt> logger)
+        ILogger<SettingsServiceRvt> logger,
+        IMessageBoxService messageBox)
     {
         _settingsService = settingsService;
         _dataConnection = dataConnection;
         _logger = logger;
+        _messageBox = messageBox;
 
         _schema = null;
     }
@@ -87,6 +92,15 @@ internal class SettingsServiceRvt : ISettingsServiceRvt
         {
             _schema = GetSchema(new Guid(_schemaGuidV3));
             _logger.LogDebug("Found schema V3");
+        }
+
+        // Check for newer schema versions that this application doesn't support
+        int newerSchemaVersion = DetectNewerSchemas();
+        if (newerSchemaVersion > _latestSchemaVersion)
+        {
+            _logger.LogWarning("Transmittal settings schema version {NewerVersion} detected, but application only supports up to version {LatestVersion}", newerSchemaVersion, _latestSchemaVersion);
+            _messageBox.ShowOk("Application version", "You appear to be opening a Revit file which was created or edited with a newer version of Transmittal. Please check for software updates.");
+            throw new SchemaVersionTooNewException(newerSchemaVersion, _latestSchemaVersion);
         }
 
         if (_schema != null)
@@ -714,6 +728,53 @@ internal class SettingsServiceRvt : ISettingsServiceRvt
             }
             return false;
         }
+    }
+
+    private int DetectNewerSchemas()
+    {
+        int newerSchemaVersion = -1;
+        IList<Schema> schemas = Schema.ListSchemas();
+
+        foreach (Schema schema in schemas)
+        {
+            // Only check schemas belonging to Transmittal vendor
+            if (!schema.VendorId.Equals( _vendorID,  StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // Check if schema name matches Transmittal pattern
+            if (!schema.SchemaName.StartsWith("TransmittalAppSettings"))
+            {
+                continue;
+            }
+
+            // Extract version number from schema name (e.g., "TransmittalAppSettingsV4" -> 4)
+            string schemaName = schema.SchemaName;
+            int version = 0;
+
+            // Try to parse version from name
+            if (schemaName == "TransmittalAppSettings")
+            {
+                version = 0;
+            }
+            else if (schemaName.StartsWith("TransmittalAppSettingsV") && int.TryParse(schemaName.Substring("TransmittalAppSettingsV".Length), out int parsedVersion))
+            {
+                version = parsedVersion;
+            }
+            else
+            {
+                continue; // Skip if we can't parse the version
+            }
+
+            // Track the highest newer version found
+            if (version > _latestSchemaVersion && version > newerSchemaVersion)
+            {
+                newerSchemaVersion = version;
+            }
+        }
+
+        return newerSchemaVersion;
     }
 
     private DataStorage FindDataStorageElement(Document doc, Schema schema)

--- a/source/Transmittal/Views/RevisionsView.xaml.cs
+++ b/source/Transmittal/Views/RevisionsView.xaml.cs
@@ -68,9 +68,13 @@ public partial class RevisionsView : Window
         if (sender is System.Windows.Controls.TextBox box)
         {
             if (string.IsNullOrEmpty(box.Text))
+            {
                 box.Background = (ImageBrush)FindResource("watermark");
+            }
             else
+            {
                 box.Background = null;
+            }
         }
 
         this.sfDataGridRevisions.SearchHelper.SearchBrush = Brushes.Green;
@@ -89,7 +93,9 @@ public class GridSelectionControllerExt : GridSelectionController
     {
         base.ProcessSelectedItemChanged(handle);
         if (handle.NewValue != null)
+        {
             this.DataGrid.ScrollInView(this.CurrentCellManager.CurrentRowColumnIndex);
+        }
     }
 
 }


### PR DESCRIPTION
Handle newer Transmittal schema versions gracefully

Add SchemaVersionTooNewException and detection logic to prevent opening settings/transmittal dialogs with unsupported schema versions. Improve null/empty checks in UI components and update SettingsServiceRvt to use IMessageBoxService for user notifications.