### PR TITLE
Updated DWG export service

### DIFF
--- a/source/Transmittal/Services/ExportDWGService.cs
+++ b/source/Transmittal/Services/ExportDWGService.cs
@@ -103,9 +103,7 @@ internal class ExportDWGService : IExportDWGService
 
                     foreach (Autodesk.Revit.DB.View v in usedViews)
                     {
-                        lviews.Add(v.Id);
-                        // export the view
-
+                        lviews = new List<ElementId> { v.Id };
 
                         string viewFileName = exportFileName.Replace(".dwg", "-view_" + v.Name + ".dwg");
 

--- a/source/Transmittal/Services/ExportDWGService.cs
+++ b/source/Transmittal/Services/ExportDWGService.cs
@@ -137,6 +137,8 @@ internal class ExportDWGService : IExportDWGService
         var activeSettings = ExportDWGSettings.GetActivePredefinedSettings(exportDocument);
         var exportOptions = activeSettings?.GetDWGExportOptions();
 
+        exportOptions.MergedViews = true; //force this to merge the views by default
+
         return exportOptions ?? new DWGExportOptions();
     }
 

--- a/source/Transmittal/Services/ExportDWGService.cs
+++ b/source/Transmittal/Services/ExportDWGService.cs
@@ -107,14 +107,14 @@ internal class ExportDWGService : IExportDWGService
                         lviews.Add(v.Id);
                         // export the view
 #if REVIT2018
-                        string ViewFileName = exportFileName.Replace( ".dwg", "-view_" + v.ViewName + ".dwg");
-                        exportDocument.Export(folderPath, ViewFileName, lviews, dwgExportOptions);
+                        string viewFileName = exportFileName.Replace( ".dwg", "-view_" + v.ViewName + ".dwg");
+                        exportDocument.Export(folderPath, viewFileName, lviews, dwgExportOptions);
 #else
-                        string ViewFileName = exportFileName.Replace(".dwg", "-view_" + v.Name + ".dwg");
-                        exportDocument.Export(folderPath, ViewFileName, lviews, dwgExportOptions);
+                        string viewFileName = exportFileName.Replace(".dwg", "-view_" + v.Name + ".dwg");
+                        exportDocument.Export(folderPath, viewFileName, lviews, dwgExportOptions);
 #endif
 
-                        pcpFile = Path.Combine(folderPath, ViewFileName.ToLower().Replace(".dwg", ".pcp"));
+                        pcpFile = Path.Combine(folderPath, viewFileName.ToLower().Replace(".dwg", ".pcp"));
                         if (File.Exists(pcpFile))
                         {
                             File.Delete(pcpFile);

--- a/source/Transmittal/Services/ExportDWGService.cs
+++ b/source/Transmittal/Services/ExportDWGService.cs
@@ -93,7 +93,7 @@ internal class ExportDWGService : IExportDWGService
                     {
                         Autodesk.Revit.DB.View usedView = exportDocument.GetElement(id) as Autodesk.Revit.DB.View;
 
-                        // only export floor plans, 3D views and ceiling plans iin shared coordinates to avoid exporting
+                        // only export floor plans and ceiling plans in shared coordinates to avoid exporting
                         // views that are not georeferenced and therefore not in the correct location in AutoCAD
                         if (usedView.ViewType == ViewType.FloorPlan ||
                             usedView.ViewType == ViewType.CeilingPlan )

--- a/source/Transmittal/Services/ExportDWGService.cs
+++ b/source/Transmittal/Services/ExportDWGService.cs
@@ -155,11 +155,11 @@ internal class ExportDWGService : IExportDWGService
         }
 
         var activeSettings = ExportDWGSettings.GetActivePredefinedSettings(exportDocument);
-        var exportOptions = activeSettings?.GetDWGExportOptions();
+        var exportOptions = activeSettings?.GetDWGExportOptions() ?? new DWGExportOptions();
 
         exportOptions.MergedViews = true; //force this to merge the views by default
 
-        return exportOptions ?? new DWGExportOptions();
+        return exportOptions;
     }
 
     public List<string> GetDocumentDWGLayerMappings(Document exportDocument)

--- a/source/Transmittal/Services/ExportDWGService.cs
+++ b/source/Transmittal/Services/ExportDWGService.cs
@@ -10,7 +10,6 @@ using Transmittal.Models;
 using Transmittal.Library.Services;
 using Transmittal.Library.Extensions;
 using Microsoft.Extensions.Logging;
-using System.Windows.Media.Animation;
 
 namespace Transmittal.Services;
 internal class ExportDWGService : IExportDWGService
@@ -110,16 +109,18 @@ internal class ExportDWGService : IExportDWGService
 
                         string viewFileName = exportFileName.Replace(".dwg", "-view_" + v.Name + ".dwg");
 
-                        if (File.Exists(viewFileName) == true)
+                        var viewFullPath = Path.Combine(folderPath, viewFileName);
+                        if (File.Exists(viewFullPath))
                         {
                             try
                             {
-                                File.Delete(viewFileName);
+                                File.Delete(viewFullPath);
                             }
                             catch (Exception ex)
                             {
                                 _logger.LogError(ex, "Error deleting existing DWG");
                                 viewFileName = viewFileName.Replace(".dwg", $"({DateTime.Now.ToLongTimeString().Replace(":", "")}).dwg");
+                                viewFullPath = Path.Combine(folderPath, viewFileName);
                             }
                         }
 

--- a/source/Transmittal/Services/ExportDWGService.cs
+++ b/source/Transmittal/Services/ExportDWGService.cs
@@ -10,6 +10,7 @@ using Transmittal.Models;
 using Transmittal.Library.Services;
 using Transmittal.Library.Extensions;
 using Microsoft.Extensions.Logging;
+using System.Windows.Media.Animation;
 
 namespace Transmittal.Services;
 internal class ExportDWGService : IExportDWGService
@@ -91,7 +92,14 @@ internal class ExportDWGService : IExportDWGService
                     foreach (ElementId id in vs.GetAllPlacedViews())
                     {
                         Autodesk.Revit.DB.View usedView = exportDocument.GetElement(id) as Autodesk.Revit.DB.View;
-                        usedViews.Insert(usedView);
+
+                        // only export floor plans, 3D views and ceiling plans iin shared coordinates to avoid exporting
+                        // views that are not georeferenced and therefore not in the correct location in AutoCAD
+                        if (usedView.ViewType == ViewType.FloorPlan ||
+                            usedView.ViewType == ViewType.CeilingPlan )
+                        {
+                            usedViews.Insert(usedView);
+                        }
                     }
 
                     foreach (Autodesk.Revit.DB.View v in usedViews)
@@ -99,8 +107,8 @@ internal class ExportDWGService : IExportDWGService
                         lviews.Add(v.Id);
                         // export the view
 #if REVIT2018
-                            string ViewFileName = exportFileName.Replace( ".dwg", "-view_" + v.ViewName + ".dwg");
-                            exportDocument.Export(folderPath, ViewFileName, lviews, dwgExportOptions);
+                        string ViewFileName = exportFileName.Replace( ".dwg", "-view_" + v.ViewName + ".dwg");
+                        exportDocument.Export(folderPath, ViewFileName, lviews, dwgExportOptions);
 #else
                         string ViewFileName = exportFileName.Replace(".dwg", "-view_" + v.Name + ".dwg");
                         exportDocument.Export(folderPath, ViewFileName, lviews, dwgExportOptions);

--- a/source/Transmittal/Services/ExportDWGService.cs
+++ b/source/Transmittal/Services/ExportDWGService.cs
@@ -61,7 +61,7 @@ internal class ExportDWGService : IExportDWGService
                     catch (Exception ex)
                     {
                         _logger.LogError(ex, "Error deleting existing DWG");
-                        exportFileName.Replace(".dwg", $"({DateTime.Now.ToLongTimeString().Replace(":", "")}).dwg");
+                        exportFileName = exportFileName.Replace(".dwg", $"({DateTime.Now.ToLongTimeString().Replace(":", "")}).dwg");
                         fullPath = Path.Combine(folderPath, exportFileName);
                     }
                 }
@@ -106,13 +106,24 @@ internal class ExportDWGService : IExportDWGService
                     {
                         lviews.Add(v.Id);
                         // export the view
-#if REVIT2018
-                        string viewFileName = exportFileName.Replace( ".dwg", "-view_" + v.ViewName + ".dwg");
-                        exportDocument.Export(folderPath, viewFileName, lviews, dwgExportOptions);
-#else
+
+
                         string viewFileName = exportFileName.Replace(".dwg", "-view_" + v.Name + ".dwg");
+
+                        if (File.Exists(viewFileName) == true)
+                        {
+                            try
+                            {
+                                File.Delete(viewFileName);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex, "Error deleting existing DWG");
+                                viewFileName = viewFileName.Replace(".dwg", $"({DateTime.Now.ToLongTimeString().Replace(":", "")}).dwg");
+                            }
+                        }
+
                         exportDocument.Export(folderPath, viewFileName, lviews, dwgExportOptions);
-#endif
 
                         pcpFile = Path.Combine(folderPath, viewFileName.ToLower().Replace(".dwg", ".pcp"));
                         if (File.Exists(pcpFile))


### PR DESCRIPTION
#### PR Classification
Bug fix and code cleanup to improve DWG export reliability and maintainability.

#### PR Summary
This pull request refines the DWG export process by restricting exported views, improving file handling, and simplifying the codebase.
- ExportDWGService.cs: Restricts export to floor and ceiling plans in shared coordinates, fixes file name update after failed deletions, adds logic to delete existing DWG files before export, removes Revit 2018 conditional code, and sets `MergedViews` to true in export options.

closes #203 
